### PR TITLE
No longer automatically import all of rxjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^21.1.2",
     "jest": "^21.2.1",
-    "rxjs": "5.4.3",
+    "rxjs": "^5.5.5",
     "ts-jest": "^21.1.2",
     "tslint": "^5.7.0",
     "tslint-microsoft-contrib": "^5.0.1",

--- a/spec/BehaviorRelay.spec.ts
+++ b/spec/BehaviorRelay.spec.ts
@@ -4,7 +4,9 @@
  */
 
 import { Relay, BehaviorRelay } from '../dist/RxRelay';
-import { Observable, Observer } from 'rxjs';
+import { Observer } from 'rxjs/Observer';
+import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
 
 describe('BehaviorRelay', () => {
   it('should extend Relay', () => {
@@ -172,7 +174,7 @@ describe('BehaviorRelay', () => {
   });
 
   it('should be an Observer which can be given to Observable.subscribe (without error)', () => {
-    const source = Observable.of(1, 2, 3, 4, 5);
+    const source = of(1, 2, 3, 4, 5);
 
     const relay = new BehaviorRelay(0);
     const expected = [0, 1, 2, 3, 4, 5];

--- a/spec/Relay.spec.ts
+++ b/spec/Relay.spec.ts
@@ -4,7 +4,11 @@
  */
 
 import { Relay, BehaviorRelay, AnonymousRelay } from '../dist/RxRelay';
-import { Observable, Observer, TestScheduler } from 'rxjs';
+import { Observable } from 'rxjs/Observable';
+import { Observer } from 'rxjs/Observer';
+import { TestScheduler } from 'rxjs/testing/TestScheduler';
+import { of } from 'rxjs/observable/of';
+import { delay } from 'rxjs/operators/delay';
 
 let rxTestScheduler: TestScheduler;
 let hot;
@@ -148,7 +152,7 @@ describe('Relay', () => {
   it('should have a static create function that works', () => {
     expect(typeof Relay.create).toBe('function');
     
-    const source = Observable.of(1, 2, 3, 4, 5);
+    const source = of(1, 2, 3, 4, 5);
     const nexts = [];
     const output = [];
 
@@ -207,7 +211,7 @@ describe('Relay', () => {
   });
 
   it('should be an Observer which can be given to Observable.subscribe (without error)', () => {
-    const source = Observable.of(1, 2, 3, 4, 5);
+    const source = of(1, 2, 3, 4, 5);
 
     const relay = new Relay();
     const expected = [1, 2, 3, 4, 5];
@@ -223,7 +227,7 @@ describe('Relay', () => {
   });
 
   it('should be usable as an Observer of a finite delayed Observable', done => {
-    const source = Observable.of(1, 2, 3).delay(50);
+    const source = of(1, 2, 3).pipe(delay(50));
     const relay = new Relay();
 
     const expected = [1, 2, 3];
@@ -305,7 +309,7 @@ describe('AnonymousRelay', () => {
 
     const relay = Relay.create(null, new Observable((observer: Observer<any>) => {
       subscribed = true;
-      const subscription = Observable.of('x').subscribe(observer);
+      const subscription = of('x').subscribe(observer);
       return () => {
         subscription.unsubscribe();
       };

--- a/spec/RxRelay.spec.ts
+++ b/spec/RxRelay.spec.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Relay } from '../dist/RxRelay';
+
+describe('RxRelay', () => {
+  it('should not import all of RxJS', () => {
+    expect(Relay.prototype.zip).toBe(undefined);
+    expect(Relay.prototype.mergeMap).toBe(undefined);
+  });
+});

--- a/src/Action.ts
+++ b/src/Action.ts
@@ -12,7 +12,7 @@
  */
 
 import { IScheduler } from './Scheduler';
-import { Subscription } from 'rxjs';
+import { Subscription } from 'rxjs/Subscription';
 
 /**
  * A unit of work to be executed in a {@link Scheduler}. An action is typically

--- a/src/BehaviorRelay.ts
+++ b/src/BehaviorRelay.ts
@@ -4,7 +4,8 @@
  */
 
 import { Relay } from './Relay';
-import { Subscriber, Subscription } from 'rxjs';
+import { Subscriber } from 'rxjs/Subscriber';
+import { Subscription } from 'rxjs/Subscription';
 
 /**
  * Emits the most recent observed event and all subsequent events to observers once they have subscribed.

--- a/src/ObserveOnSubscriber.ts
+++ b/src/ObserveOnSubscriber.ts
@@ -11,7 +11,8 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-import { Subscriber, Notification } from 'rxjs';
+import { Subscriber } from 'rxjs/Subscriber';
+import { Notification } from 'rxjs/Notification';
 import { Action } from './Action';
 import { IScheduler } from './Scheduler';
 import { PartialObserver } from './Observer';

--- a/src/Relay.ts
+++ b/src/Relay.ts
@@ -3,17 +3,13 @@
  * Licensed under the MIT License.
  */
 
-import { 
-    Observable,
-    Observer,
-    Operator,
-    Subscription,
-    Symbol,
-    Subscriber 
-} from 'rxjs';
+import { Operator } from 'rxjs/Operator';
+import { rxSubscriber } from 'rxjs/symbol/rxSubscriber';
+import { Subscriber } from 'rxjs/Subscriber';
+import { Subscription } from 'rxjs/Subscription';
+import { Observer } from 'rxjs/Observer';
+import { Observable } from 'rxjs/Observable';
 import { RelaySubscription } from './RelaySubscription';
-
-const rxSubscriberSymbol = Symbol.rxSubscriber;
 
 /**
  * Emits all subsequent events to observers once they have subscribed.
@@ -30,7 +26,7 @@ class RelaySubscriber<T> extends Subscriber<T> {
  */
 class Relay<T> extends Observable<T> {
 
-  [rxSubscriberSymbol]() {
+  [rxSubscriber]() {
     return new RelaySubscriber(this);
   }
 

--- a/src/RelaySubscription.ts
+++ b/src/RelaySubscription.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { Observer, Subscription } from 'rxjs';
+import { Observer } from 'rxjs/Observer';
+import { Subscription } from 'rxjs/Subscription';
 import { Relay } from './Relay';
 
 /**

--- a/src/ReplayRelay.ts
+++ b/src/ReplayRelay.ts
@@ -6,7 +6,9 @@
 import { Relay } from './Relay';
 import { IScheduler } from './Scheduler';
 import { RelaySubscription } from './RelaySubscription';
-import { Subscriber, Subscription, Scheduler } from 'rxjs';
+import { queue as queueScheduler } from 'rxjs/scheduler/queue';
+import { Subscription } from 'rxjs/Subscription';
+import { Subscriber } from 'rxjs/Subscriber';
 import { ObserveOnSubscriber } from './ObserveOnSubscriber';
 
 /**
@@ -54,7 +56,7 @@ export class ReplayRelay<T> extends Relay<T> {
   }
 
   _getNow(): number {
-    return (this.scheduler || Scheduler.queue).now();
+    return (this.scheduler || queueScheduler).now();
   }
 
   private _trimBufferThenGetEvents(): ReplayEvent<T>[] {

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -12,7 +12,7 @@
  */
 
 import { Action } from './Action';
-import { Subscription } from 'rxjs';
+import { Subscription } from 'rxjs/Subscription';
 
 export interface IScheduler {
   now(): number;


### PR DESCRIPTION
Previously this lib imports all of rxjs, which means that if the consuming app wishes to only import what they use using [operator patching](https://github.com/ReactiveX/rxjs#es6-via-npm) or using [lettable operators](https://github.com/ReactiveX/rxjs/blob/master/doc/lettable-operators.md) + tree shaking it this library would still pull everything in no matter what.

As far as the lib code itself, the fix just meant importing the dependencies directly instead of importing them from the root `"rxjs"`.

e.g.

```diff
- import { Observable, Observer } from 'rxjs';
+ import { Observer } from 'rxjs/Observer';
+ import { Observable } from 'rxjs/Observable';
```

In the tests, this meant also not including all operators too because otherwise we wouldn't be able to confirm it doesn't later accidentally import them all again and regress. This is accomplished by using the new ["lettable" aka "pipeable" aka something else yet-to-be-coined](https://github.com/ReactiveX/rxjs/blob/master/doc/lettable-operators.md) operators.

While the lettable operators are useful in their own right, they may or may not eventually become more ergonomic [if JS gets the pipeline operator](https://github.com/tc39/proposal-pipeline-operator):

```diff
- of(1, 2, 3).pipe(
-   map(d => d * 10),
-   filter(d => d > 10)
- ).subscribe(d => console.log(d));

+ of(1, 2, 3)
+   |> map(d => d * 10)
+   |> filter(d => d > 10)
+   .subscribe(d => console.log(d));
```

This is far from certain though, of course.