### PR TITLE
"Relay" should be "ReplayRelay"

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ observerB: 3
 Emits all previously observed and subsequent events to observers once they have subscribed.
 
 ```js
-var relay = new Relay();
+var relay = new ReplayRelay();
 
 relay.subscribe({
   next: (v) => console.log('observerA: ' + v)


### PR DESCRIPTION
If I understood it correctly, the third example should instantiate a `ReplayRelay`, not a `Relay` ?