### PR TITLE
Bump rxjs version to 6.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
   "devDependencies": {
     "@types/jest": "^21.1.2",
     "jest": "^21.2.1",
-    "rxjs": "^5.5.11",
+    "rxjs": "^6.3.3",
     "ts-jest": "^21.1.2",
     "tslint": "^5.7.0",
     "tslint-microsoft-contrib": "^5.0.1",
     "typescript": "^2.5.3"
   },
   "peerDependencies": {
-    "rxjs": "^5.5.11"
+    "rxjs": "^6.3.3"
   },
   "repository": {
     "type": "git",

--- a/spec/BehaviorRelay.spec.ts
+++ b/spec/BehaviorRelay.spec.ts
@@ -4,9 +4,7 @@
  */
 
 import { Relay, BehaviorRelay } from '../dist/RxRelay';
-import { Observer } from 'rxjs/Observer';
-import { Observable } from 'rxjs/Observable';
-import { of } from 'rxjs/observable/of';
+import { Observable, Observer, of } from 'rxjs';
 
 describe('BehaviorRelay', () => {
   it('should extend Relay', () => {
@@ -145,7 +143,7 @@ describe('BehaviorRelay', () => {
     relay.next('foo');
     relay.subscribe(x => results2.push(x));
     relay.next('bar');
-    
+
     expect(results1).toEqual(['init', 'foo', 'bar']);
     expect(results2).toEqual(['foo', 'bar']);
   });

--- a/spec/Relay.spec.ts
+++ b/spec/Relay.spec.ts
@@ -4,11 +4,9 @@
  */
 
 import { Relay, BehaviorRelay, AnonymousRelay } from '../dist/RxRelay';
-import { Observable } from 'rxjs/Observable';
-import { Observer } from 'rxjs/Observer';
-import { TestScheduler } from 'rxjs/testing/TestScheduler';
-import { of } from 'rxjs/observable/of';
-import { delay } from 'rxjs/operators/delay';
+import { Observable, Observer, of } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
+import { delay } from 'rxjs/operators';
 
 let rxTestScheduler: TestScheduler;
 let hot;
@@ -17,7 +15,7 @@ let expectObservable;
 beforeAll(() => {
   rxTestScheduler = new TestScheduler((actual, expected) => expect(actual).toEqual(expected));
   hot = (marbles: string, values?: any, error?: any) => rxTestScheduler.createHotObservable(marbles, values, error);
-  expectObservable = (observable: Observable<any>, unsubscriptionMarbles: string = null) => 
+  expectObservable = (observable: Observable<any>, unsubscriptionMarbles: string = null) =>
     rxTestScheduler.expectObservable(observable, unsubscriptionMarbles);
 });
 
@@ -32,7 +30,7 @@ describe('Relay', () => {
 
     relay.next('foo');
     relay.next('bar');
-    
+
     expect(expected.length).toBe(0);
   });
 
@@ -52,10 +50,10 @@ describe('Relay', () => {
     });
 
     expect(relay.observers.length).toBe(2);
-    
+
     relay.next('foo');
     relay.next('bar');
-    
+
     expect(i).toBe(2);
     expect(j).toBe(2);
   });
@@ -71,7 +69,7 @@ describe('Relay', () => {
     relay.next('foo');
     relay.error(new Error('Should be ignored'));
     relay.next('bar');
-    
+
     expect(expected.length).toBe(0);
   });
 
@@ -86,7 +84,7 @@ describe('Relay', () => {
     relay.next('foo');
     relay.complete();
     relay.next('bar');
-    
+
     expect(expected.length).toBe(0);
   });
 
@@ -151,7 +149,7 @@ describe('Relay', () => {
 
   it('should have a static create function that works', () => {
     expect(typeof Relay.create).toBe('function');
-    
+
     const source = of(1, 2, 3, 4, 5);
     const nexts = [];
     const output = [];

--- a/spec/ReplayRelay.spec.ts
+++ b/spec/ReplayRelay.spec.ts
@@ -4,12 +4,9 @@
  */
 
 import { Relay, ReplayRelay } from '../dist/RxRelay';
-import { Observable } from 'rxjs/Observable';
-import { Observer } from 'rxjs/Observer';
-import { TestScheduler } from 'rxjs/testing/TestScheduler';
-import { of } from 'rxjs/observable/of';
-import { mergeMapTo } from 'rxjs/operators/mergeMapTo';
-import { tap } from 'rxjs/operators/tap';
+import { Observable, Observer, of } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
+import { mergeMapTo, tap } from 'rxjs/operators';
 
 let rxTestScheduler: TestScheduler;
 let hot;
@@ -18,7 +15,7 @@ let expectObservable;
 beforeAll(() => {
   rxTestScheduler = new TestScheduler((actual, expected) => expect(actual).toEqual(expected));
   hot = (marbles: string, values?: any, error?: any) => rxTestScheduler.createHotObservable(marbles, values, error);
-  expectObservable = (observable: Observable<any>, unsubscriptionMarbles: string = null) => 
+  expectObservable = (observable: Observable<any>, unsubscriptionMarbles: string = null) =>
     rxTestScheduler.expectObservable(observable, unsubscriptionMarbles);
 });
 
@@ -68,7 +65,7 @@ describe('ReplayRelay', () => {
 
     relay.subscribe((x: number) => {
       expect(x).toBe(expected.shift());
-    }, 
+    },
     err => fail(),
     () => fail());
 
@@ -98,7 +95,7 @@ describe('ReplayRelay', () => {
     it('should replay 2 previous values when subscribed', () => {
       const relay = new ReplayRelay(2);
       const expected = [2, 3];
-  
+
       let i = 0;
       relay.next(1);
       relay.next(2);
@@ -106,7 +103,7 @@ describe('ReplayRelay', () => {
       relay.subscribe((x: number) => {
         expect(x).toBe(expected[i++]);
       });
-  
+
       expect(i).toBe(2);
     });
 

--- a/src/Action.ts
+++ b/src/Action.ts
@@ -12,7 +12,7 @@
  */
 
 import { IScheduler } from './Scheduler';
-import { Subscription } from 'rxjs/Subscription';
+import { Subscription } from 'rxjs';
 
 /**
  * A unit of work to be executed in a {@link Scheduler}. An action is typically

--- a/src/BehaviorRelay.ts
+++ b/src/BehaviorRelay.ts
@@ -4,8 +4,7 @@
  */
 
 import { Relay } from './Relay';
-import { Subscriber } from 'rxjs/Subscriber';
-import { Subscription } from 'rxjs/Subscription';
+import { Subscriber, Subscription } from 'rxjs';
 
 /**
  * Emits the most recent observed event and all subsequent events to observers once they have subscribed.

--- a/src/ObserveOnSubscriber.ts
+++ b/src/ObserveOnSubscriber.ts
@@ -11,8 +11,7 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-import { Subscriber } from 'rxjs/Subscriber';
-import { Notification } from 'rxjs/Notification';
+import { Notification, Subscriber } from 'rxjs';
 import { Action } from './Action';
 import { IScheduler } from './Scheduler';
 import { PartialObserver } from './Observer';

--- a/src/Relay.ts
+++ b/src/Relay.ts
@@ -3,32 +3,19 @@
  * Licensed under the MIT License.
  */
 
-import { Operator } from 'rxjs/Operator';
-import { rxSubscriber } from 'rxjs/symbol/rxSubscriber';
-import { Subscriber } from 'rxjs/Subscriber';
-import { Subscription } from 'rxjs/Subscription';
-import { Observer } from 'rxjs/Observer';
-import { Observable } from 'rxjs/Observable';
+import {
+  Observable,
+  Observer,
+  Operator,
+  Subscriber,
+  Subscription
+} from 'rxjs';
 import { RelaySubscription } from './RelaySubscription';
-
-/**
- * Emits all subsequent events to observers once they have subscribed.
- * @class RelaySubscriber<T>
- */
-class RelaySubscriber<T> extends Subscriber<T> {
-  constructor(protected destination: Relay<T>) {
-    super(destination);
-  }
-}
 
 /**
  * @class Relay<T>
  */
 class Relay<T> extends Observable<T> {
-
-  [rxSubscriber]() {
-    return new RelaySubscriber(this);
-  }
 
   observers: Observer<T | undefined>[] = [];
 

--- a/src/RelaySubscription.ts
+++ b/src/RelaySubscription.ts
@@ -3,8 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Observer } from 'rxjs/Observer';
-import { Subscription } from 'rxjs/Subscription';
+import { Observer, Subscription } from 'rxjs';
 import { Relay } from './Relay';
 
 /**

--- a/src/ReplayRelay.ts
+++ b/src/ReplayRelay.ts
@@ -6,9 +6,7 @@
 import { Relay } from './Relay';
 import { IScheduler } from './Scheduler';
 import { RelaySubscription } from './RelaySubscription';
-import { queue as queueScheduler } from 'rxjs/scheduler/queue';
-import { Subscription } from 'rxjs/Subscription';
-import { Subscriber } from 'rxjs/Subscriber';
+import { queueScheduler, Subscriber, Subscription } from 'rxjs';
 import { ObserveOnSubscriber } from './ObserveOnSubscriber';
 
 /**

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -12,7 +12,7 @@
  */
 
 import { Action } from './Action';
-import { Subscription } from 'rxjs/Subscription';
+import { Subscription } from 'rxjs';
 
 export interface IScheduler {
   now(): number;


### PR DESCRIPTION
It seems there are no breaking changes for migrating rxjs to `6.x.x` 😃

I removed `RelaySubscriber` because checking `rxSubscriber` symbol in RxJS is removed.(https://github.com/ReactiveX/rxjs/pull/4182)